### PR TITLE
Complying with kddi chatwork

### DIFF
--- a/lib/goodbye_chatwork.rb
+++ b/lib/goodbye_chatwork.rb
@@ -27,8 +27,13 @@ module GoodbyeChatwork
     end
 
     def login
-      @client.post '/login.php', email: @id, password: @pw, autologin: 'on'
-      r = @client.get '/'
+      login_r = @client.post '/login.php', email: @id, password: @pw, autologin: 'on'
+      if login_r.env.status == 302
+	@client.url_prefix = URI.parse(login_r.env.response_headers[:location].match(/^https?(:\/\/[-_.!~*\'()a-zA-Z0-9;\:\@&=+\$,%#]+)/).to_s)
+        @client.get login_r.env.response_headers[:location]
+      end
+
+      r = @client.get "/"
       self.wait
       self.info "login as #{@id} ..."
       @token = r.body.match(/var ACCESS_TOKEN = '(.+)'/).to_a[1]


### PR DESCRIPTION
This PR enables using goodbye_chatwork with KDDI ChatWork.

I ran `goodbye_chatwork -i hoge@fuga.com -p piyopiyopass` and goodbye_chatwork raised "no token"(RuntimeError) in 'login' method.

```
% goodbye_chatwork -i hoge@fuga.com -p piyopiyopass
2016-07-15T14:41:52+09:00 login as hoge@fuga.com ...
/Users/hirokishirai/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/goodbye_chatwork-0.0.3/lib/goodbye_chatwork.rb:36:in `login': no token (RuntimeError)
	from /Users/hirokishirai/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/goodbye_chatwork-0.0.3/bin/goodbye_chatwork:37:in `<top (required)>'
	from /Users/hirokishirai/.rbenv/versions/2.3.1/bin/goodbye_chatwork:23:in `load'
	from /Users/hirokishirai/.rbenv/versions/2.3.1/bin/goodbye_chatwork:23:in `<main>'
```

This Exception is due to 302 redirect to KDDI ChatWork.
KDDI ChatWork is plan of chatwork for enterprises.

For now, KDDI ChatWork's URL is "https://kcw.kddi.ne.jp". but, this URL  might change by system owner. So, I use regexp to get redirect URL.