### PR TITLE
Corresponding to new chatwork page document

### DIFF
--- a/lib/goodbye_chatwork.rb
+++ b/lib/goodbye_chatwork.rb
@@ -36,8 +36,8 @@ module GoodbyeChatwork
       r = @client.get "/"
       self.wait
       self.info "login as #{@id} ..."
-      @token = r.body.match(/var ACCESS_TOKEN = '(.+)'/).to_a[1]
-      @myid = r.body.match(/var myid = '(.+)'/).to_a[1]
+      @token = r.body.match(/var ACCESS_TOKEN *= *'(.+)'/).to_a[1]
+      @myid = r.body.match(/var myid *= *'(.+)'/).to_a[1]
       raise 'no token' unless @token
       self.init_load
       self.get_account_info


### PR DESCRIPTION

ChatWork seems to change some lines declaring variables.
from
```ruby
var ACCESS_TOKEN = '**************************';
var myid = '*******';
```
to
```ruby
var ACCESS_TOKEN               = '**************************';
var myid                       = '*******';
```

I changed the regular expression for new ChatWork document.
Please refer to [#7 RuntimeError no token](https://github.com/swdyh/goodbye_chatwork/issues/7).