### PR TITLE
Fix old_chat result order

### DIFF
--- a/lib/goodbye_chatwork.rb
+++ b/lib/goodbye_chatwork.rb
@@ -71,7 +71,7 @@ module GoodbyeChatwork
       end
       self.wait
       r = JSON.parse(res.body)
-      r['result']['chat_list'].sort_by { |i| i['id'] }.reverse
+      r['result']['chat_list'].sort_by { |i| i['id'].to_i }.reverse
     end
 
     def account(aid)

--- a/lib/goodbye_chatwork.rb
+++ b/lib/goodbye_chatwork.rb
@@ -71,7 +71,7 @@ module GoodbyeChatwork
       end
       self.wait
       r = JSON.parse(res.body)
-      r['result']['chat_list'].sort_by { |i| - i['id'] }
+      r['result']['chat_list'].sort_by { |i| i['id'] }.reverse
     end
 
     def account(aid)


### PR DESCRIPTION
At first, thank you for your developing this awesome tools.

I changed a sort procedure to avoid loading duplicate messages.
Message-ids are returned as **string** not integer, 
then negative operator (to reverse sort) of ```- i['id']``` is not effected.
This modification may resolve issue #22 .

I checked it on Windows7, ruby 2.4.1, and gem 2.6.11.

I am sorry but I am not good at Ruby, so if this modification is not a good Ruby's habit,
please give me some feedback.

Regards,